### PR TITLE
invert comparison

### DIFF
--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -1,11 +1,11 @@
 check_pandoc_version <- function(minimum = "2.0.0", recommend = "2.7.2") {
-  if(!rmarkdown::pandoc_available("2.0.0")) {
+  if(!rmarkdown::pandoc_available(minimum)) {
     warning("minidown supports Pandoc >= 2.7.2, but system uses Pandoc < 2.0, ",
             "which is too old.")
     return(FALSE)
   }
 
-  if (rmarkdown::pandoc_available(recommend)) {
+  if (!rmarkdown::pandoc_available(recommend)) {
     warning("minidown supports Pandoc >= ", recommend, " ",
             "Pandoc with older versions may result in unexpected behaviors.")
   }


### PR DESCRIPTION
I am using the version of `pandoc` that ships with version of RStudio I use (which is a fairly current nightly):

```sh
edd@rob:~$ pandoc --version
pandoc 2.9.2.1
Compiled with pandoc-types 1.20, texmath 0.12.0.1, skylighting 0.8.3.2
Default user data directory: /home/edd/.local/share/pandoc or /home/edd/.pandoc
Copyright (C) 2006-2020 John MacFarlane
Web:  https://pandoc.org
This is free software; see the source for copying conditions.
There is no warranty, not even for merchantability or fitness
for a particular purpose.
edd@rob:~$ 
```

It is sufficient for `rmarkdown` and correctly recognised:

```r
R> rmarkdown::pandoc_available("2.0.0")
[1] TRUE
R> rmarkdown::pandoc_available("2.7.2")
[1] TRUE
R> rmarkdown::pandoc_available("2.9.2.1")
[1] TRUE
R> rmarkdown::pandoc_available("2.9.2.2")
[1] FALSE
R> 
```

Yet when I render I document I get a spurious warning:

```
Warning message:
In check_pandoc_version(minimum = "2.0.0", recommend = "2.7.2") :
  minidown supports Pandoc >= 2.7.2 Pandoc with older versions may result in unexpected behaviors.
```

Correcting the boolean as in the PR corrects this.   As an aside, I fear the warning may be a little too noisy for CRAN. Packages using `minidown` will now be creating warnings---is that what we want?  Would be possible to suppress this?
