### PR TITLE
fix css jitter due to border-radius change on button hover

### DIFF
--- a/inst/frameworks/sakura/sakura-dark-solarized.css
+++ b/inst/frameworks/sakura/sakura-dark-solarized.css
@@ -140,7 +140,7 @@ textarea {
     opacity: .5; }
   .button:focus, .button:hover, button:focus, button:hover, input[type="submit"]:focus, input[type="submit"]:hover, input[type="reset"]:focus, input[type="reset"]:hover, input[type="button"]:focus, input[type="button"]:hover {
     background-color: #657b83;
-    border-color: #657b83;
+    border: 1px solid #657b83;
     color: #002b36;
     outline: 0; }
 

--- a/inst/frameworks/sakura/sakura-dark.css
+++ b/inst/frameworks/sakura/sakura-dark.css
@@ -140,7 +140,7 @@ textarea {
     opacity: .5; }
   .button:focus, .button:hover, button:focus, button:hover, input[type="submit"]:focus, input[type="submit"]:hover, input[type="reset"]:focus, input[type="reset"]:hover, input[type="button"]:focus, input[type="button"]:hover {
     background-color: #c9c9c9;
-    border-color: #c9c9c9;
+    border: 1px solid #c9c9c9;
     color: #222222;
     outline: 0; }
 

--- a/inst/frameworks/sakura/sakura-earthly.css
+++ b/inst/frameworks/sakura/sakura-earthly.css
@@ -139,7 +139,7 @@ textarea {
     opacity: .5; }
   .button:focus, .button:hover, button:focus, button:hover, input[type="submit"]:focus, input[type="submit"]:hover, input[type="reset"]:focus, input[type="reset"]:hover, input[type="button"]:focus, input[type="button"]:hover {
     background-color: #5e5e5e;
-    border-color: #5e5e5e;
+    border: 1px solid #5e5e5e;
     color: #f9f9f9;
     outline: 0; }
 

--- a/inst/frameworks/sakura/sakura-vader.css
+++ b/inst/frameworks/sakura/sakura-vader.css
@@ -140,7 +140,7 @@ textarea {
     opacity: .5; }
   .button:focus, .button:hover, button:focus, button:hover, input[type="submit"]:focus, input[type="submit"]:hover, input[type="reset"]:focus, input[type="reset"]:hover, input[type="button"]:focus, input[type="button"]:hover {
     background-color: #DA4453;
-    border-color: #DA4453;
+    border: 1px solid #DA4453;
     color: #120c0e;
     outline: 0; }
 

--- a/inst/frameworks/sakura/sakura.css
+++ b/inst/frameworks/sakura/sakura.css
@@ -136,7 +136,7 @@ textarea {
     opacity: .5; }
   .button:focus, .button:hover, button:focus, button:hover, input[type="submit"]:focus, input[type="submit"]:hover, input[type="reset"]:focus, input[type="reset"]:hover, input[type="button"]:focus, input[type="button"]:hover {
     background-color: #982c61;
-    border-color: #982c61;
+    border: 1px solid #982c61;
     color: #f9f9f9;
     outline: 0; }
 


### PR DESCRIPTION
Hi there :) I discovered your cool project by chance on GitHub and noticed that on your example document https://minidown.atusy.net/ the text shifts when the download-Rmd button is hovered. This PR makes sure the border width of buttons doesn't change on hover so the document doesn't jitter.