### PR TITLE
Tweak floating ToC

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * Add **spcss** as a new CSS framework (#37).
 * The ToC is more compact. Also, when the ToC floats, it streches as high as viewport. Previous height was 85% of the viewport height (#40, #41).
 * Added skeleton.Rmd, which means users can create `minidown::mini_document` from the menu of RStudio (**File** -> **New File** -> **R Markdown...** -> **From Template**) (#42).
+* The floating ToC has better appearance. Its width remains 300px, but the main contents has changed. If viewport width is between 960px to 1260px, the main contents fills the rest of width (660px to 960px). If viewport width is larger than 1200px, the main content has the fixed width of 960px, and is centered. Previously, contents including the floating ToC are centered (#44).
 
 # minidown 0.0.3
 

--- a/inst/rmarkdown/html/styles/common.css
+++ b/inst/rmarkdown/html/styles/common.css
@@ -1,4 +1,4 @@
-@media screen and (max-width: 900px) {
+@media screen and (max-width: 960px) {
   header, nav, article {
     padding: 0 3rem;
   }

--- a/inst/rmarkdown/html/styles/feat-toc-float.css
+++ b/inst/rmarkdown/html/styles/feat-toc-float.css
@@ -1,27 +1,25 @@
+:root {
+  --toc-width: 300px;
+  --main-width: calc(450px + 50vw);
+}
+
+body {
+  max-width: 100vw;
+  padding: 0;
+}
+
 @media screen and (min-width: 900px) {
-  body {
-    min-width: 900px;
-    max-width: 62.5%;
-    margin: 0 auto;
-    padding-top: 0;
-    padding-bottom: 0;
-  }
   main {
     display: grid;
-    grid-template-columns: 300px 1fr;
+    grid-template-columns: var(--toc-width) 1fr;
     grid-template-rows: auto auto;
-  }
-  header, article {
-    min-width: calc(600px - 4rem);
-    max-width: calc(100% - 4rem);
-    padding: 0 0 0 4rem;
   }
   #TOC {
     grid-row: 1 / -1;
     grid-column: 1 / 2;
     border: none;
     margin: 0;
-    width: 300px;
+    width: var(--toc-width);
   }
   #TOC > ul {
     position: sticky;
@@ -29,5 +27,17 @@
     overflow-y: auto;
     top: 5px;
     border: none;
+  }
+}
+
+
+@media screen and (min-width: 900px) {
+  main {
+    width: var(--main-width);
+    margin: 0 calc(50vw - 0.5 * var(--main-width) + 0.5 * var(--toc-width)) 0 auto;
+  }
+  header, article {
+    width: calc(var(--main-width) - var(--toc-width) - 6rem);
+    padding: 0 0 0 4rem;
   }
 }

--- a/inst/rmarkdown/html/styles/feat-toc-float.css
+++ b/inst/rmarkdown/html/styles/feat-toc-float.css
@@ -1,14 +1,13 @@
 :root {
   --toc-width: 300px;
-  --main-width: calc(450px + 50vw);
 }
 
-body {
-  max-width: 100vw;
-  padding: 0;
-}
-
-@media screen and (min-width: 900px) {
+@media screen and (min-width: 960px) {
+  body {
+    max-width: 100vw;
+    margin: 0;
+    padding: 0;
+  }
   main {
     display: grid;
     grid-template-columns: var(--toc-width) 1fr;
@@ -22,22 +21,37 @@ body {
     width: var(--toc-width);
   }
   #TOC > ul {
+    padding-top: 0;
+    padding-bottom: 0;
     position: sticky;
     max-height: 100vh;
     overflow-y: auto;
-    top: 5px;
+    top: 0;
     border: none;
+  }
+  #TOC > ul > li:first-child {
+    padding-top: 0.5rem;
   }
 }
 
 
-@media screen and (min-width: 900px) {
+@media screen and (min-width: 960px) and (max-width: 1260px) {
   main {
-    width: var(--main-width);
-    margin: 0 calc(50vw - 0.5 * var(--main-width) + 0.5 * var(--toc-width)) 0 auto;
+    width: calc(100vw - 2rem);
   }
   header, article {
-    width: calc(var(--main-width) - var(--toc-width) - 6rem);
+    width: calc(100vw - var(--toc-width) - 6rem);
+    padding: 0 0 0 4rem;
+  }
+}
+
+@media screen and (min-width: 1260px) {
+  main {
+    width: calc(1260px - 2rem);
+    margin: 0 calc(50vw - 480px) 0 auto;
+  }
+  header, article {
+    width: calc(960px - 6rem);
     padding: 0 0 0 4rem;
   }
 }


### PR DESCRIPTION
From NEWS.md

> The floating ToC has better appearance. Its width remains 300px, but the main contents has changed. If viewport width is between 960px to 1260px, the main contents fills the rest of width (660px to 960px). If viewport width is larger than 1200px, the main content has the fixed width of 960px, and is centered. Previously, contents including the floating ToC are centered