### PR TITLE
Cheat `R CMD check`

### DIFF
--- a/R/mini-document.R
+++ b/R/mini-document.R
@@ -124,5 +124,4 @@ mini_document <- function(framework = "sakura",
   )
 }
 
-guess_type <- mime::guess_type
-
+if (FALSE) guess_type <- mime::guess_type


### PR DESCRIPTION
mime doesn't really need to be imported in this package. This is just a trick to cheat `R CMD check` so that it doesn't give the false positive note.

https://github.com/atusy/minidown/issues/59#issuecomment-954736937